### PR TITLE
Fixed 'missing java.lang classes' problem

### DIFF
--- a/src/main/java/com/intellij/compiler/instrumentation/InstrumentationClassFinder.java
+++ b/src/main/java/com/intellij/compiler/instrumentation/InstrumentationClassFinder.java
@@ -54,7 +54,7 @@ public class InstrumentationClassFinder {
     // look into classpath
     final Resource resource = myClasspath.getResource(resourceName, false);
     if (resource == null) {
-      throw new ClassNotFoundException("Class not found: " + internalName);
+        is = ClassLoader.getSystemResourceAsStream(resourceName);
     } else {
       is = resource.getInputStream();
     }


### PR DESCRIPTION
Checks current ClassLoader for Class before throwing ClassNotFoundException.
